### PR TITLE
Remove drunkenness feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * **🤖 Intelligent Character AI**: This isn't just simple scripting. A character AI powered by a Large Language Model (LLM) reacts to your words and expresses emotions in real-time.
 * **📚 Dynamic Scenario System**: The story isn't hard-coded. Scenarios are loaded and managed from an external `json` file, allowing for easy addition and expansion of new storylines.
 * **🎨 Adaptive UI**: Button sizes and heights dynamically adjust based on the length of the dialogue text, always providing optimal readability.
-* **💖 Emotion State Management**: Based on your choices, the character's 'Affinity' and 'Drunkenness' levels change in real-time, directly impacting their tone, reactions, and the story's branching points.
+* **💖 Emotion State Management**: Based on your choices, the character's 'Affinity' level changes in real-time, directly impacting their tone, reactions, and the story's branching points.
 
 -----
 

--- a/app/src/main/java/com/secretlovemode/CharacterAi.kt
+++ b/app/src/main/java/com/secretlovemode/CharacterAi.kt
@@ -14,8 +14,7 @@ data class ChatMessage(val role: String, val content: String) {
 
 data class GameResponse(
     val characterResponse: String,
-    val newAffinity: Int,
-    val newDrunkenness: Int
+    val newAffinity: Int
 )
 
 class CharacterAi(
@@ -87,8 +86,7 @@ class CharacterAi(
             Log.w(TAG, "モデルが準備されていません。generateGameResponse 処理不可。")
             return GameResponse(
                 "ごめんなさい、今はちょっと考えられません。（モデル準備エラー）",
-                gameState.affinity,
-                gameState.drunkenness
+                gameState.affinity
             )
         }
         Log.d(TAG, "generateGameResponse 開始 (Thread: ${Thread.currentThread().name})")
@@ -96,21 +94,19 @@ class CharacterAi(
             // 1. キャラクター応答生成
             val characterResponse = generateCharacterResponse(gameState, playerSelectedOption, conversationHistory, scenario)
 
-            // 2. パラメータ更新 (好感度と酔い具合を同時に計算)
-            val updatedParameters = calculateUpdatedParameters(gameState, playerSelectedOption, characterResponse, conversationHistory, scenario)
+            // 2. パラメータ更新 (好感度を計算)
+            val newAffinity = calculateUpdatedAffinity(gameState, playerSelectedOption, characterResponse, conversationHistory, scenario)
 
             Log.d(TAG, "generateGameResponse 完了 (Thread: ${Thread.currentThread().name})")
             GameResponse(
                 characterResponse,
-                updatedParameters.first, // 新しい好感度
-                updatedParameters.second // 新しい酔い具合レベル
+                newAffinity
             )
         } catch (e: Exception) {
             Log.e(TAG, "ゲーム応答生成中にエラー発生: ${e.message}", e)
             GameResponse(
                 "ごめんなさい、ちょっと混乱しています。（エラー発生）",
-                gameState.affinity,
-                gameState.drunkenness
+                gameState.affinity
             )
         }
     }
@@ -172,23 +168,23 @@ $conversationContext
     """.trimIndent()
     }
 
-    private fun calculateUpdatedParameters(
+    private fun calculateUpdatedAffinity(
         gameState: GameState,
         playerSelectedOption: String,
         characterResponse: String,
         conversationHistory: List<ChatMessage>,
         scenario: Scenario // シナリオ情報を追加
-    ): Pair<Int, Int> {
+    ): Int {
         if (llmInference == null) {
-            Log.w(TAG, "llmInference is null in calculateUpdatedParameters.")
-            return Pair(gameState.affinity, gameState.drunkenness)
+            Log.w(TAG, "llmInference is null in calculateUpdatedAffinity.")
+            return gameState.affinity
         }
         val prompt = buildParameterUpdatePrompt(gameState, playerSelectedOption, characterResponse, conversationHistory, scenario)
         Log.d(TAG, "パラメータ更新プロンプト: $prompt")
         Log.d(TAG, "llmInference?.generateResponse(parameter) 呼び出し前 (Thread: ${Thread.currentThread().name})")
         val response = llmInference?.generateResponse(prompt)
         Log.d(TAG, "llmInference?.generateResponse(parameter) 呼び出し後 (Thread: ${Thread.currentThread().name})")
-        return parseParameterUpdate(response, gameState.affinity, gameState.drunkenness)
+        return parseParameterUpdate(response, gameState.affinity)
     }
 
     private fun buildParameterUpdatePrompt(
@@ -225,37 +221,27 @@ ${gameState.characterName}(後輩):「$characterResponse」
 - ややネガティブなやり取り: -1 ～ -4
 - 非常にネガティブなやり取り: -5 ～ -10
 
-次の形式で、変化量を示す数字のみを返答してください (例: +2,0 または -3,0):
-好感度変化,酔いの進行度変化
+次の形式で、変化量を示す数字のみを返答してください (例: +2 または -3):
+好感度変化
 判定結果:
 <|assistant|>
     """.trimIndent()
     }
 
-    private fun parseParameterUpdate(response: String?, currentAffinity: Int, currentDrunkenness: Int): Pair<Int, Int> {
+    private fun parseParameterUpdate(response: String?, currentAffinity: Int): Int {
         if (response.isNullOrBlank()) {
-            return Pair(currentAffinity, currentDrunkenness)
+            return currentAffinity
         }
 
         return try {
             val cleanResponse = response.replace(" ", "").replace("　", "") // 空白除去
-            val parts = cleanResponse.split(",")
-
-            if (parts.size >= 2) {
-                val affinityChange = parts[0].replace("+", "").toIntOrNull() ?: 0
-                val drunkennessChange = parts[1].replace("+", "").toIntOrNull() ?: 0
-
-                val newAffinity = (currentAffinity + affinityChange).coerceIn(0, 100)
-                val newDrunkenness = (currentDrunkenness + drunkennessChange).coerceIn(0, 100)
-
-                Log.d(TAG, "パラメータ更新: 好感度 $currentAffinity -> $newAffinity, 酔い具合 $currentDrunkenness -> $newDrunkenness")
-                Pair(newAffinity, newDrunkenness)
-            } else {
-                Pair(currentAffinity, currentDrunkenness)
-            }
+            val affinityChange = cleanResponse.replace("+", "").toIntOrNull() ?: 0
+            val newAffinity = (currentAffinity + affinityChange).coerceIn(0, 100)
+            Log.d(TAG, "パラメータ更新: 好感度 $currentAffinity -> $newAffinity")
+            newAffinity
         } catch (e: Exception) {
             Log.e(TAG, "パラメータ解析エラー: ${e.message}")
-            Pair(currentAffinity, currentDrunkenness)
+            currentAffinity
         }
     }
 

--- a/app/src/main/java/com/secretlovemode/GameActivity.kt
+++ b/app/src/main/java/com/secretlovemode/GameActivity.kt
@@ -39,7 +39,6 @@ class GameActivity : AppCompatActivity() {
     private lateinit var questionButton3: Button
     private lateinit var tvCharacterName: TextView
     private lateinit var tvAffinity: TextView
-    private lateinit var tvDrunkenness: TextView
     private lateinit var ivCharacter: ImageView
     private lateinit var scrollViewConversation: ScrollView
 
@@ -117,7 +116,6 @@ class GameActivity : AppCompatActivity() {
         tvCharacterName.setTextColor(ContextCompat.getColor(this, R.color.text_accent))
         tvConversation.setTextColor(ContextCompat.getColor(this, R.color.text_primary))
         tvAffinity.setTextColor(ContextCompat.getColor(this, R.color.affinity_color))
-        tvDrunkenness.setTextColor(ContextCompat.getColor(this, R.color.drunkenness_color))
         listOf(questionButton1, questionButton2, questionButton3).forEach { button ->
             button.backgroundTintList = ContextCompat.getColorStateList(this, R.color.button_primary)
             button.setTextColor(ContextCompat.getColor(this, R.color.white))
@@ -246,7 +244,6 @@ class GameActivity : AppCompatActivity() {
 
     private fun updateStatusDisplay() {
         animateStatusUpdate(tvAffinity, "好感度: ${gameState.affinity} (${gameState.getAffinityDescription()})")
-        animateStatusUpdate(tvDrunkenness, "酔い具合: ${gameState.drunkenness} (${gameState.getDrunkennessDescription()})")
         val affinityColor = when {
             gameState.affinity <= 0 -> android.R.color.holo_red_dark
             gameState.affinity < 30 -> android.R.color.holo_red_light
@@ -254,8 +251,7 @@ class GameActivity : AppCompatActivity() {
             else -> R.color.affinity_color
         }
         tvAffinity.setTextColor(ContextCompat.getColor(this, affinityColor))
-        tvDrunkenness.setTextColor(ContextCompat.getColor(this, R.color.drunkenness_color))
-        Log.d("GameActivity", "Status Updated - Affinity: ${gameState.affinity}, Drunkenness: ${gameState.drunkenness}")
+        Log.d("GameActivity", "Status Updated - Affinity: ${gameState.affinity}")
     }
 
     private fun animateStatusUpdate(textView: TextView, newText: String) {
@@ -372,7 +368,6 @@ class GameActivity : AppCompatActivity() {
 
                 gameState = gameState.copy(
                     affinity = gameResponse.newAffinity,
-                    drunkenness = gameResponse.newDrunkenness,
                     conversationCount = gameState.conversationCount + 1
                 )
 

--- a/app/src/main/java/com/secretlovemode/GameState.kt
+++ b/app/src/main/java/com/secretlovemode/GameState.kt
@@ -5,7 +5,6 @@ data class GameState(
     val characterPersona: String = "真面目で優秀な大学院生。指導教官であるプレイヤーに惹かれているが、その気持ちを悟られないよう必死に隠している。冷静沈着を装っているが、内心は常に揺れ動いている。",
     val currentSituation: String = "研究室で、指導教官のあなたと二人きりで話している。",
     val affinity: Int = 40, // 초기 호감도를 더 낮게 설정
-    val drunkenness: Int = 0,
     val conversationCount: Int = 0,
     val currentScenarioId: String = "DEFAULT" // 현재 시나리오 ID를 저장. "DEFAULT"는 일반 대화 상태.
 
@@ -20,13 +19,6 @@ data class GameState(
         else -> "最悪"
     }
 
-    fun getDrunkennessDescription(): String = when {
-        drunkenness >= 80 -> "かなり酔っている"
-        drunkenness >= 60 -> "酔っている"
-        drunkenness >= 40 -> "ほろ酔い"
-        drunkenness >= 20 -> "少し酔っている"
-        else -> "素面"
-    }
     
     // 호감도 변화량을 더 엄격하게 계산
     fun calculateAffinityChange(playerChoice: String, characterResponse: String): Int {

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -15,7 +15,6 @@
 
     <!-- 상태 표시 색상 (다크모드에서도 잘 보이게) -->
     <color name="affinity_color">#FFFF8A8A</color>
-    <color name="drunkenness_color">#FF7DEDE6</color>
 
     <!-- 텍스트 색상 (다크모드) -->
     <color name="text_primary">#FFFFFFFF</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,7 +13,6 @@
 
     <!-- 상태 표시 색상 -->
     <color name="affinity_color">#FFFF6B6B</color>
-    <color name="drunkenness_color">#FF4ECDC4</color>
 
     <!-- 텍스트 색상 -->
     <color name="text_primary">#FF2C2C2C</color>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -21,10 +21,6 @@
         <item name="android:textColor">@color/affinity_color</item>
     </style>
 
-    <!-- 취기 스타일 -->
-    <style name="StatusText.Drunkenness">
-        <item name="android:textColor">@color/drunkenness_color</item>
-    </style>
 
     <!-- 대화 텍스트 스타일 -->
     <style name="ConversationText">


### PR DESCRIPTION
## Summary
- simplify emotion tracking to only use affinity
- drop drunkenness values and styles from resources
- refactor CharacterAi and GameActivity to remove drunkenness logic
- clean up README and GameState

## Testing
- `./gradlew help` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_686f3959b2a0832394a01228b71b1f5d