### PR TITLE
Fix Kotlin version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To build and run this project, you will need the following:
 
 - Android Studio (Latest version recommended)
 - Android SDK (Target: API 35)
-- Kotlin 2.0
+- Kotlin 2.0.21
 - Java SDK 21
 
 ### Installation and Running


### PR DESCRIPTION
## Summary
- update Kotlin version in prerequisites section

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_686f4248d4c48323a22efca6363affe2